### PR TITLE
Version upgrade proceeds after adding Recoil-related utilities and dependencies

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "trailingComma": "all",
-  "printWidth": 100,
+  "printWidth": 80,
   "useTabs": false,
   "tabWidth": 2,
   "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@types/react-dom": "^17.0.11",
     "classnames": "^2.3.1",
     "next": "11.1.2",
     "react": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-nextjs-boilerplate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,3 @@
+> API Folder
+
+This folder is for managing API related settings and common logic.

--- a/src/containers/README.md
+++ b/src/containers/README.md
@@ -1,0 +1,3 @@
+> Containers
+
+This folder is basically responsible for the layout and all logic that is configured.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -1,0 +1,3 @@
+> Hooks
+
+This folder is responsible for common logic related to React-Hooks. However, prefix can only be used with names that include 'use'.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './makeGetKey';

--- a/src/utils/makeGetKey.ts
+++ b/src/utils/makeGetKey.ts
@@ -1,0 +1,7 @@
+/**
+ * @description Util to solve key duplication problem that occurs during
+ * server-side rendering when using Recoil
+ */
+
+export const makeGetKey = (domain: string) => (key: string) =>
+  `${typeof window === 'undefined' && '_'}${domain}-${key}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,6 +825,22 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@17.0.27":
   version "17.0.27"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.27.tgz#6498ed9b3ad117e818deb5525fa1946c09f2e0e6"
@@ -2721,6 +2737,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -4863,6 +4884,11 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-recoilize@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-recoilize/-/react-recoilize-1.0.3.tgz#849dec7976959a6299a9cf4ffdce474187c78674"
+  integrity sha512-SE1coBKSVzM113dQXxCfeEhz/d2oi7uUYZ8ie3Ci4okO+jVo7GsalWlrY4IcthxWR+enxxfOUHJsRDSs8z0Hfw==
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -4930,6 +4956,13 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.4.1.tgz#1cb2171bc98d41361507131a059d7c3525d8c4fe"
+  integrity sha512-vp6KPwlHOjJ4bJofmdDchmgI9ilMTCoUisK8/WYLl8dThH7e7KmtZttiLgvDb2Em99dUfTEsk8vT8L1nUMgqXQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 redent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
@0xBono
- chore(pkg): update from version 0.1.0 to version 0.1.1
- docs: add readme document that describes the folder
- chore(prettier): change the printWidth from 100 to 80
- feat(utils): add util for key duplication problem when using Recoil
- chore(deps): add @types/react-dom dependency